### PR TITLE
LandingPage Issue Fix

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,14 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: false,
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "media-cldnry.s-nbcnews.com",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,7 +31,10 @@ export default function Home() {
           <div className="chat chat-start ml-2 ">
             <div className="chat-image avatar">
                 <div className="w-10 bg-blue-950 text-center text-3xl text-white rounded-full">
-                  <Image alt="Image" src="https://media-cldnry.s-nbcnews.com/image/upload/t_fit-1000w,f_auto,q_auto:best/rockcms/2022-03/220312-hailey-bieber-mjf-1403-2c7ede.jpg" />
+                  <Image alt="Image" src="https://media-cldnry.s-nbcnews.com/image/upload/t_fit-1000w,f_auto,q_auto:best/rockcms/2022-03/220312-hailey-bieber-mjf-1403-2c7ede.jpg"
+                  width={40}
+                  height={40}
+                  />
                 </div>
             </div>
             <div className="chat-header text-xl">Hailey<time className="text-xl opacity-50">22:47</time></div>


### PR DESCRIPTION
Since next.js doesn't allow external images from unknown domains by default when using the next/image component, we need to allowlist the image domain(nbcnews.com) in next.config.ts file. The change made is the same.

